### PR TITLE
Fix Java version mismatch in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+      <!-- Align compiler properties with plugin configuration -->
+      <maven.compiler.source>1.8</maven.compiler.source>
+      <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -44,8 +45,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
           <configuration>
-  <source>8</source>
-  <target>8</target>
+  <source>1.8</source>
+  <target>1.8</target>
 </configuration>
 
         </plugin>


### PR DESCRIPTION
## Summary
- align Java version in pom.xml properties and plugin configuration

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f511ac2508321a2c629933d8a29d5